### PR TITLE
Code-like data should be in a monospaced font

### DIFF
--- a/flask_debugtoolbar/static/css/toolbar.css
+++ b/flask_debugtoolbar/static/css/toolbar.css
@@ -22,6 +22,11 @@
 	text-align:left;
 }
 
+#flDebug caption, #flDebug tbody, #flDebug tfoot, #flDebug thead, #flDebug tr, #flDebug th, #flDebug td {
+	font-family: 'ubuntu mono', menlo, monaco, consolas, courier, mono, sans-serif;
+}
+
+
 #flDebug #flDebugToolbar {
 	background:#111;
 	width:200px;


### PR DESCRIPTION
This makes reading all the data in the tables much easier to process, as it is in code. 
