### PR TITLE
add DEBUG_TB_ENABLED setting which overrides app.debug check

### DIFF
--- a/flask_debugtoolbar/__init__.py
+++ b/flask_debugtoolbar/__init__.py
@@ -36,7 +36,7 @@ class DebugToolbarExtension(object):
         self.debug_toolbars = {}
         self.hosts = ()
 
-        if not app.debug:
+        if not app.debug and not app.config.get('DEBUG_TB_ENABLED'):
             return
 
         if not app.config.get('SECRET_KEY'):


### PR DESCRIPTION
Useful when you don't want to run your app in debug mode but do want to have the toolbar enabled.
