### PR TITLE
Add configuration parameter to enable profiler by default

### DIFF
--- a/flask_debugtoolbar/panels/profiler.py
+++ b/flask_debugtoolbar/panels/profiler.py
@@ -20,6 +20,11 @@ class ProfilerDebugPanel(DebugPanel):
 
     user_activate = True
 
+    def __init__(self, jinja_env, context={}):
+        DebugPanel.__init__(self, jinja_env, context=context)
+        if current_app.config.get('DEBUG_TB_PROFILER_ENABLED'):
+            self.is_active = True
+
     def has_content(self):
         return bool(self.profiler)
 


### PR DESCRIPTION
If you want to save all/some of your reports automatically you might want to have profiler information there as well, which is not available by default.

New config variables:
DEBUG_TB_PROFILER_ENABLED - makes profiler panel enabled by default.
