### PR TITLE
Debugging of ajax and saving reports

### DIFF
--- a/flask_debugtoolbar/__init__.py
+++ b/flask_debugtoolbar/__init__.py
@@ -161,14 +161,14 @@ class DebugToolbarExtension(object):
 
         app = current_app
         toolbar_html = None
-        # check if explicitly specified to process response
-        if app.config.get('DEBUG_TB_FORCE_DEBUG'):
+        # check if explicitly specified to dump all debug information
+        # force processing of toolbar in this case
+        if app.config.get('DEBUG_TB_DUMP_CALLBACK'):
             for panel in self.debug_toolbars[real_request].panels:
                 panel.process_response(real_request, response)
             toolbar_html = self.debug_toolbars[real_request].render_toolbar()
 
-            if app.config.get('DEBUG_TB_DUMP_CALLBACK'):
-                app.config.get('DEBUG_TB_DUMP_CALLBACK')(toolbar_html)
+            app.config.get('DEBUG_TB_DUMP_CALLBACK')(toolbar_html)
 
         # If the http response code is 200 then we process to add the
         # toolbar to the returned html response.


### PR DESCRIPTION
This patch makes it possible to debug ajax calls and json/javascript based api calls together with facilities to force debugging and saving reports (slow ones for example) somewhere.

New config variables:

DEBUG_TB_FORCE_DEBUG_PARAMETER - specifies GET parameter to force debugtoolbar activation. Might be used for debugging ajax request and json/javascript-typed responses.

DEBUG_TB_DUMP_CALLBACK - if set enables profiling (but not showing debugtoolbar) for all requests. Specifies function that will be called after each request with toolbar html provided.
