### PR TITLE
Extension Import Transition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Usage
 Setting up the debug toolbar is simple::
 
     from flask import Flask
-    from flask_debugtoolbar import DebugToolbarExtension
+    from flask.ext.debugtoolbar import DebugToolbarExtension
 
     app = Flask(__name__)
 

--- a/example/example.py
+++ b/example/example.py
@@ -2,17 +2,17 @@ import sys
 sys.path.insert(0, '.')
 
 from flask import Flask, render_template, redirect, url_for
-from flaskext.script import Manager
-from flaskext.sqlalchemy import SQLAlchemy
-from flask_debugtoolbar import DebugToolbarExtension
+from flask.ext.script import Manager
+from flask.ext.sqlalchemy import SQLAlchemy
+from flask.ext.debugtoolbar import DebugToolbarExtension
 
 
 app = Flask(__name__)
 app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = True
 #app.config['DEBUG_TB_PANELS'] = (
-#    'flask_debugtoolbar.panels.headers.HeaderDebugPanel',
-#    'flask_debugtoolbar.panels.logger.LoggingPanel',
-#    'flask_debugtoolbar.panels.timer.TimerDebugPanel',
+#    'flask.ext.debugtoolbar.panels.headers.HeaderDebugPanel',
+#    'flask.ext.debugtoolbar.panels.logger.LoggingPanel',
+#    'flask.ext.debugtoolbar.panels.timer.TimerDebugPanel',
 #)
 #app.config['DEBUG_TB_HOSTS'] = ('127.0.0.1', '::1' )
 app.config['SECRET_KEY'] = 'asd'


### PR DESCRIPTION
from: http://flask.pocoo.org/docs/extensiondev/#extension-import-transition

For a while we recommended using namespace packages for Flask extensions. This turned out to be problematic in practice because many different competing namespace package systems exist and pip would automatically switch between different systems and this caused a lot of problems for users.

Instead we now recommend naming packages flask_foo instead of the now deprecated flaskext.foo. Flask 0.8 introduces a redirect import system that lets uses import from flask.ext.foo and it will try flask_foo first and if that fails flaskext.foo.

Flask extensions should urge users to import from flask.ext.foo instead of flask_foo or flaskext_foo so that extensions can transition to the new package name without affecting users.
