### PR TITLE
Profiler: Use update_wrapper on partial

### DIFF
--- a/flask_debugtoolbar/panels/profiler.py
+++ b/flask_debugtoolbar/panels/profiler.py
@@ -37,7 +37,9 @@ class ProfilerDebugPanel(DebugPanel):
 
     def process_view(self, request, view_func, view_kwargs):
         if self.is_active:
-            return functools.partial(self.profiler.runcall, view_func)
+            func = functools.partial(self.profiler.runcall, view_func)
+            functools.update_wrapper(func, view_func)
+            return func
 
     def process_response(self, request, response):
         if not self.is_active:


### PR DESCRIPTION
The `update_wrapper` call is needed so that the new partial
func inherits the `__module__` of the original function.

The `__module__` is needed because the request-vars panel uses
`func.__module__` in building the qualified name.
