### PR TITLE
adding reference to noConflict'ed jQuery

### DIFF
--- a/flask_debugtoolbar/static/js/toolbar.js
+++ b/flask_debugtoolbar/static/js/toolbar.js
@@ -183,7 +183,8 @@
             document.close();
           });
           return false;
-        }
+        },
+        $: $
     };
     $(document).ready(function() {
         fldt.init();


### PR DESCRIPTION
I've got a few simple, standalone extensions for prototyping kicking around that normally wouldn't use jQuery, but could benefit from some better config UI in a panel if debugtoolbar is installed. For example, live reload of pages based on assets/template changes, switching themes, etc. could be done in-browser vs in config. Critically, cookie stuff would be handy to not have to reinvent every time i wanted to reuse this pattern.

currently, I am loading my own copy of jQuery, but it would be great to have access to the one used in `fldt` for panel-specific controls. this pull just exposes jQuery as `fldt.$`. I am sure there are other, more interesting ways to go about it, but this seemed like the simplest.

thanks for the great tool!
