### PR TITLE
Fix template editor encoding problem

### DIFF
--- a/flask_debugtoolbar/panels/template.py
+++ b/flask_debugtoolbar/panels/template.py
@@ -83,12 +83,14 @@ def template_editor(key):
     # TODO set up special loader that caches templates it loads
     # and can override template contents
     templates = [t['template'] for t in TemplateDebugPanel.get_cache_for_key(key)]
+
+    encoding = current_app.config.get('DEBUG_TB_TEMPLATE_EDITOR_ENCODING', 'utf-8')
     return g.debug_toolbar.render('panels/template_editor.html', {
         'static_path': url_for('_debug_toolbar.static', filename=''),
         'request': request,
         'templates': [
             {'name': t.name,
-             'source': open(t.filename).read()}
+             'source': open(t.filename).read().decode(encoding)}
             for t in templates
         ]
     })


### PR DESCRIPTION
I'm sorry my poor English.

If encoding of document isn't ascii, current version of template editor generate this exception.

```
  File "/.../flask_debugtoolbar/panels/template.py", line 92, in template_editor
    for t in templates
UnicodeDecodeError: 'ascii' codec can't decode byte 0xec in position 1473: ordinal not in range(128)
```

I fixed this bug, and add a new config variables:
DEBUG_TB_TEMPLATE_EDITOR_ENCODING - default is utf-8. if modify this variable, template editor recognize file's encoding.
