### PR TITLE
Port SettingsVarsDebugPanel from Django DebugToolbar

### DIFF
--- a/flask_debugtoolbar/panels/settings_vars.py
+++ b/flask_debugtoolbar/panels/settings_vars.py
@@ -1,0 +1,41 @@
+from collections import OrderedDict
+from flask import current_app
+from flask_debugtoolbar.panels import DebugPanel
+_ = lambda x: x
+
+
+class SettingsVarsDebugPanel(DebugPanel):
+    """
+    A panel to display all variables from Flask configuration
+    """
+    name = 'SettingsVars'
+    has_content = True
+
+    def nav_title(self):
+        return _('Settings')
+
+    def title(self):
+        return _('Settings')
+
+    def url(self):
+        return ''
+
+    def process_request(self, request):
+        self.request = request
+        self.settings = OrderedDict(sorted(
+            current_app.config.items(), key=lambda key_value: key_value[0]))
+        self.view_func = None
+        self.view_args = []
+        self.view_kwargs = {}
+
+    def process_view(self, request, view_func, view_kwargs):
+        self.view_func = view_func
+        self.view_kwargs = view_kwargs
+
+    def content(self):
+        context = self.context.copy()
+        context.update({
+            'settings': self.settings,
+        })
+
+        return self.render('panels/settings_vars.html', context)

--- a/flask_debugtoolbar/templates/panels/settings_vars.html
+++ b/flask_debugtoolbar/templates/panels/settings_vars.html
@@ -1,0 +1,16 @@
+<table>
+    <thead>
+        <tr>
+            <th>Setting</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for name, value in settings.items() %}
+            <tr class="{{ loop.cycle('flDebugOdd', 'flDebugEven') }}">
+                <td>{{ name }}</td>
+                <td><code>{{ value|printable }}</code></td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/flask_debugtoolbar/toolbar.py
+++ b/flask_debugtoolbar/toolbar.py
@@ -12,6 +12,7 @@ class DebugToolbar(object):
         'DEBUG_TB_PANELS': (
             'flask_debugtoolbar.panels.versions.VersionDebugPanel',
             'flask_debugtoolbar.panels.timer.TimerDebugPanel',
+            'flask_debugtoolbar.panels.settings_vars.SettingsVarsDebugPanel',
             'flask_debugtoolbar.panels.headers.HeaderDebugPanel',
             'flask_debugtoolbar.panels.request_vars.RequestVarsDebugPanel',
             'flask_debugtoolbar.panels.template.TemplateDebugPanel',


### PR DESCRIPTION
This code works on my Ubuntu 13.04 x64 box under Python 2.7.

Please let me know if you need anything from me in addition.

This code will not work on Python < 2.7 due to collections.OrderedDict usage without any fallback:
http://docs.python.org/2/library/collections.html#collections.OrderedDict
