### PR TITLE
Convert query.duration (float) to string before passing it to urlencode.

### DIFF
--- a/flask_debugtoolbar/templates/panels/sqlalchemy.html
+++ b/flask_debugtoolbar/templates/panels/sqlalchemy.html
@@ -13,8 +13,8 @@
 				<td>{{ '%.4f'|format(query.duration * 1000) }}</td>
 				<td>
 				{% if query.signed_query %}
-					<a class="remoteCall" href="/_debug_toolbar/views/sqlalchemy/sql_select?query={{ query.signed_query }}&amp;duration={{ query.duration|urlencode }}">SELECT</a><br />
-					<a class="remoteCall" href="/_debug_toolbar/views/sqlalchemy/sql_explain?query={{ query.signed_query }}&amp;duration={{ query.duration|urlencode }}">EXPLAIN</a><br />
+					<a class="remoteCall" href="/_debug_toolbar/views/sqlalchemy/sql_select?query={{ query.signed_query }}&amp;duration={{ query.duration|string|urlencode }}">SELECT</a><br />
+					<a class="remoteCall" href="/_debug_toolbar/views/sqlalchemy/sql_explain?query={{ query.signed_query }}&amp;duration={{ query.duration|string|urlencode }}">EXPLAIN</a><br />
 				{% endif %}
 				</td>
 				<td title="{{ query.context_long }}">


### PR DESCRIPTION
With the release of werkzeug 0.9 the sqlalchemy panel crashes with:

```
File ".../site-packages/werkzeug/urls.py", line 387, in url_quote
for char in bytearray(string):
TypeError: 'float' object is not iterable
```

werkzeug's url_encode[_plus] expects a string as first parameter.
