### PR TITLE
fix: #67

### DIFF
--- a/flask_debugtoolbar/utils.py
+++ b/flask_debugtoolbar/utils.py
@@ -16,6 +16,10 @@ from flask import current_app
 
 
 def format_fname(value):
+    # Keep path lowercased because os.path.commonprefix isn't case
+    # insensitive yet
+    value = value.lower()
+
     # If the value is not an absolute path, the it is a builtin or
     # a relative file (thus a project file).
     if not os.path.isabs(value):
@@ -36,7 +40,7 @@ def format_fname(value):
     prefix = None
     prefix_len = 0
     for path in sys.path:
-        new_prefix = os.path.commonprefix([path, value])
+        new_prefix = os.path.commonprefix([path.lower(), value])
         if len(new_prefix) > prefix_len:
             prefix = new_prefix
             prefix_len = len(prefix)


### PR DESCRIPTION
Basically os.path.commonprefix fails to compare paths with difference on their casing.

'C:\aaa\bbbb\ccc\ddd'  fails when comparing commonprefix with 'C:\Aaa\Bbb\Ccc\Ddd'

Output example of sys.path on Windows 7 64b:

```
['',
 'C:\\bin\\Python27\\lib\\site-packages\\pillow-2.0.0-py2.7-win32.egg',
 'C:\\bin\\Python27\\lib\\site-packages\\pil-1.1.7-py2.7-win32.egg',
 'C:\\bin\\Python27\\lib\\site-packages\\setuptools-2.2-py2.7.egg',
 'C:\\bin\\Python27\\lib\\site-packages\\mechanize-0.2.5-py2.7.egg',
 'C:\\bin\\Python27\\lib\\site-packages\\lxml-3.3.1-py2.7-win32.egg',
 'C:\\bin\\Python27\\lib\\site-packages\\distribute-0.6.49-py2.7.egg',
 'C:\\bin\\Python27\\lib\\site-packages\\sqlalchemy-0.9.3-py2.7-win32.egg',
 'C:\\bin\\Python27\\DLLs',
 'C:\\bin\\Python27\\lib',
 'C:\\bin\\Python27\\lib\\plat-win',
 'C:\\bin\\Python27\\lib\\lib-tk',
 'C:\\bin\\Python27',
 'C:\\bin\\Python27\\lib\\site-packages']
```
## Real Comparison

code:

```
print  [os.path.commonprefix([against, path]) for path in sys.path]
```
- Agains't **'c:\bin\python27\'** => []
- Agains't **'c:\bin\Python27\'** => []
- Agains't **'C:\bin\Python27\'** => ['',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27\',
   'C:\bin\Python27',
   'C:\bin\Python27\']

This way you can imagine the impact the missing **.lower()** would make on windows
