### PR TITLE
Support raw SQL Alchemy

### DIFF
--- a/flask_debugtoolbar/__init__.py
+++ b/flask_debugtoolbar/__init__.py
@@ -41,8 +41,9 @@ class DebugToolbarExtension(object):
 
     _redirect_codes = [301, 302, 303, 304]
 
-    def __init__(self, app=None):
+    def __init__(self, app=None, sqlalchemy_engine=None):
         self.app = app
+        self.engine = sqlalchemy_engine
         self.debug_toolbars = {}
 
         # Configure jinja for the internal templates and add url rules
@@ -80,8 +81,19 @@ class DebugToolbarExtension(object):
 
         app.add_url_rule('/_debug_toolbar/static/<path:filename>',
                          '_debug_toolbar.static', self.send_static_file)
+        if self.engine:
+            # use 'internal' API from flask_sqlalchemy to install events.
+            # maybe re-implement this for flask-debugtoolbar
+            from flask.ext.sqlalchemy import _EngineDebuggingSignalEvents, _record_queries
+            if _record_queries(app):
+                _EngineDebuggingSignalEvents(
+                     engine=self.engine,
+                     import_name=app.import_name).register()
 
-        app.register_blueprint(module, url_prefix='/_debug_toolbar/views')
+        app.register_blueprint(
+            module,
+            url_prefix='/_debug_toolbar/views',
+            sqlalchemy_engine=self.engine)
 
     def _default_config(self, app):
         return {

--- a/test/basic_app_plain_sqlalchemy.py
+++ b/test/basic_app_plain_sqlalchemy.py
@@ -1,0 +1,35 @@
+from flask import Flask, render_template
+from flask_debugtoolbar import DebugToolbarExtension
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.ext.declarative import declarative_base
+
+app = Flask('basic_app_plain_sqlalchemy')
+app.debug = True
+app.config['SECRET_KEY'] = 'abc123'
+
+# make sure these are printable in the config panel
+app.config['BYTES_VALUE'] = b'\x00'
+app.config['UNICODE_VALUE'] = u'\uffff'
+
+
+engine = create_engine('sqlite://')
+toolbar = DebugToolbarExtension(app, sqlalchemy_engine=engine)
+
+
+Base = declarative_base()
+class Foo(Base):
+    __tablename__ = 'foo'
+    id = Column(Integer, primary_key=True)
+
+
+@app.route('/')
+def index():
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    session.query(Foo).filter_by(id=1).all()
+    return render_template('basic_app.html')
+
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
This is an attempt to fix https://github.com/mgood/flask-debugtoolbar/issues/71.

It adds a new argument `sqlalchemy_engine` to `DebugToolbarExtension(app, sqlalchemy_engine=None)`. If no engine is passed, the old behavior is maintained. If an engine is passed, then the query recording events are installed on that engine and no `flask-sqlalchemy` `db` is touched. The event registration still uses flask-sqlalchemy code.

This still requires `flask-sqlalchemy` to be installed in order to record queries, but it does not require the user to **use** it to declare models and query for data; raw sqlalchemy engines and tables can be used instead. I added a basic app example that uses plain sql alchemy under `basic_app_raw_sqlalchemy.py`
