### PR TITLE
'ascii' codec can't decode

### DIFF
--- a/flask_debugtoolbar/panels/logger.py
+++ b/flask_debugtoolbar/panels/logger.py
@@ -101,7 +101,7 @@ class LoggingPanel(DebugPanel):
         records = []
         for record in self.get_and_delete():
             records.append({
-                'message': record.getMessage(),
+                'message': record.getMessage().decode('utf-8'),
                 'time': datetime.datetime.fromtimestamp(record.created),
                 'level': record.levelname,
                 'file': format_fname(record.pathname),


### PR DESCRIPTION
```
'message': record.getMessage().decode('utf-8'),
```

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 0: ordinal not in range(128)
