### PR TITLE
Add `init_app()` method to `DebugPanel` base class

### DIFF
--- a/src/flask_debugtoolbar/panels/__init__.py
+++ b/src/flask_debugtoolbar/panels/__init__.py
@@ -25,6 +25,29 @@ class DebugPanel(object):
         # If the client enabled the panel
         self.is_active = False
 
+    @classmethod
+    def init_app(cls, app):
+        """Method that can be overridden by child classes.
+        Can be used for setting up additional URL-rules/routes.
+
+        Example::
+
+            class UMLDiagramPanel(DebugPanel):
+
+                @classmethod
+                def init_app(cls, app):
+                    app.add_url_rule(
+                        '/_flask_debugtoolbar_umldiagram/<path:filename>',
+                        '_flask_debugtoolbar_umldiagram.serve_generated_image',
+                        cls.serve_generated_image
+                    )
+
+                @classmethod
+                def serve_generated_image(cls, app):
+                    return Response(...)
+        """
+        pass
+
     def render(self, template_name, context):
         template = self.jinja_env.get_template(template_name)
         return template.render(**context)

--- a/src/flask_debugtoolbar/toolbar.py
+++ b/src/flask_debugtoolbar/toolbar.py
@@ -48,8 +48,8 @@ class DebugToolbar(object):
     @classmethod
     def load_panels(cls, app):
         for panel_class in cls._iter_panels(app):
-            # just loop to make sure they've been loaded
-            pass
+            # Call `.init_app()` on panels
+            panel_class.init_app(app)
 
     @classmethod
     def _iter_panels(cls, app):


### PR DESCRIPTION
Adds a method `DebugPanel.init_app()` that gets called from `DebugToolbar.init_app()`.

This allows `DebugPanels` to register their own routes, and do setup work that should go across requests (as opposed to per-request setup) and needs access to the Flask `app`-object.
