### PR TITLE
Take full advantage of pytest, add missing requirements to setup.py.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 dist/
 docs/_build
 .tox
+.cache/
+.eggs/

--- a/README.rst
+++ b/README.rst
@@ -41,3 +41,11 @@ In production, setting ``app.debug = False`` will disable the toolbar.
 See the `documentation`_ for more information.
 
 .. _documentation: https://flask-debugtoolbar.readthedocs.io/
+
+
+Tests
+-----
+
+To run the included unit tests, run `python setup.py test`.
+
+To run individual tests, you first need to install the requirements with `pip install .[tests]`, before running the tests with `python -m pytest test/<test_file>.py::<test>`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[aliases]
+test=pytest
+
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,31 @@ except Exception:
     CHANGES = ''
 
 
+install_requires = [
+    'Flask>=0.8',
+    'Blinker',
+    'itsdangerous',
+    'werkzeug',
+],
+
+tests_require = [
+    'pytest>=3.0.5',
+    'Flask-SQLAlchemy'
+]
+
+extras_require = {
+    'tests': tests_require,
+}
+
+setup_requires = [
+    'pytest-runner>=2.6.2'
+]
+
+extras_require['all'] = []
+for reqs in extras_require.values():
+    extras_require['all'].extend(reqs)
+
+
 setup(
     name='Flask-DebugToolbar',
     version='0.12.dev0',
@@ -30,12 +55,10 @@ setup(
         'flask_debugtoolbar',
         'flask_debugtoolbar.panels'
     ],
-    install_requires=[
-        'Flask>=0.8',
-        'Blinker',
-        'itsdangerous',
-        'werkzeug',
-    ],
+    extras_require=extras_require,
+    install_requires=install_requires,
+    tests_require=tests_require,
+    setup_requires=setup_requires,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,49 @@
 import pytest
 
+from flask import Flask, render_template
+from flask_sqlalchemy import SQLAlchemy
+
+from flask_debugtoolbar import DebugToolbarExtension
+
 
 @pytest.fixture(autouse=True)
 def mock_env_development(monkeypatch):
     monkeypatch.setenv("FLASK_ENV", "development")
+
+
+@pytest.fixture
+def app(request):
+    app = Flask(__name__)
+
+    app.debug = True
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "abc123"
+
+    # make sure these are printable in the config panel
+    app.config["BYTES_VALUE"] = b"\x00"
+    app.config["UNICODE_VALUE"] = u"\uffff"
+
+    # config overrides
+    if "config" in request.keywords:
+        for key, value in request.keywords["config"].kwargs.items():
+            app.config[key] = value
+
+    toolbar = DebugToolbarExtension(app)
+    db = SQLAlchemy(app)
+
+    class Foo(db.Model):
+        __tablename__ = "foo"
+        id = db.Column(db.Integer, primary_key=True)
+
+    @app.route("/")
+    def index():
+        db.create_all()
+        Foo.query.filter_by(id=1).all()
+        return render_template("basic_app.html")
+
+    return app
+
+
+@pytest.fixture
+def client(request, app):
+    return app.test_client()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,40 +16,40 @@ def app_no_extensions(request):
     """ Flask app only, without any extensions. """
     _app = Flask(__name__)
 
-    app.debug = True
-    app.config["TESTING"] = True
-    app.config["SECRET_KEY"] = "abc123"
+    _app.debug = True
+    _app.config["TESTING"] = True
+    _app.config["SECRET_KEY"] = "abc123"
 
     # make sure these are printable in the config panel
-    app.config["BYTES_VALUE"] = b"\x00"
-    app.config["UNICODE_VALUE"] = u"\uffff"
+    _app.config["BYTES_VALUE"] = b"\x00"
+    _app.config["UNICODE_VALUE"] = u"\uffff"
 
     # config overrides
     if "config" in request.keywords:
         for key, value in request.keywords["config"].kwargs.items():
-            app.config[key] = value
+            _app.config[key] = value
 
     return _app
 
 
 @pytest.fixture
 def app(request, app_no_extensions):
-    app = app_no_extensions
+    _app = app_no_extensions
 
-    toolbar = DebugToolbarExtension(app)
-    db = SQLAlchemy(app)
+    toolbar = DebugToolbarExtension(_app)
+    db = SQLAlchemy(_app)
 
     class Foo(db.Model):
         __tablename__ = "foo"
         id = db.Column(db.Integer, primary_key=True)
 
-    @app.route("/")
+    @_app.route("/")
     def index():
         db.create_all()
         Foo.query.filter_by(id=1).all()
         return render_template("basic_app.html")
 
-    return app
+    return _app
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,8 +12,9 @@ def mock_env_development(monkeypatch):
 
 
 @pytest.fixture
-def app(request):
-    app = Flask(__name__)
+def app_no_extensions(request):
+    """ Flask app only, without any extensions. """
+    _app = Flask(__name__)
 
     app.debug = True
     app.config["TESTING"] = True
@@ -27,6 +28,13 @@ def app(request):
     if "config" in request.keywords:
         for key, value in request.keywords["config"].kwargs.items():
             app.config[key] = value
+
+    return _app
+
+
+@pytest.fixture
+def app(request, app_no_extensions):
+    app = app_no_extensions
 
     toolbar = DebugToolbarExtension(app)
     db = SQLAlchemy(app)

--- a/test/test_toolbar.py
+++ b/test/test_toolbar.py
@@ -5,15 +5,8 @@ import pytest
 from flask_debugtoolbar import _printable
 
 
-def load_app(name):
-    app = __import__(name).app
-    app.config['TESTING'] = True
-    return app.test_client()
-
-
-def test_basic_app():
-    app = load_app('basic_app')
-    index = app.get('/')
+def test_basic_app(app, client):
+    index = client.get('/')
     assert index.status_code == 200
     assert b'<div id="flDebug"' in index.data
 

--- a/test/test_toolbar.py
+++ b/test/test_toolbar.py
@@ -2,13 +2,31 @@ import sys
 
 import pytest
 
-from flask_debugtoolbar import _printable
+from flask_debugtoolbar import _printable, DebugToolbarExtension
 
 
 def test_basic_app(app, client):
     index = client.get('/')
     assert index.status_code == 200
     assert b'<div id="flDebug"' in index.data
+
+
+@pytest.mark.config(
+    DEBUG_TB_ENABLED=False
+)
+def test_toolbar_disabled(app, client):
+    index = client.get('/')
+    assert index.status_code == 200
+    assert b'<div id="flDebug"' not in index.data
+
+
+@pytest.mark.config(
+    SECRET_KEY=None
+)
+def test_toolbar_no_secret_key(app_no_extensions):
+    with pytest.raises(RuntimeError) as exc:
+        DebugToolbarExtension(app_no_extensions)
+        assert all(s in str(exc) for s in ['requires', 'SECRET_KEY'])
 
 
 @pytest.mark.skipif(sys.version_info >= (3,),


### PR DESCRIPTION
By taking full advantage of pytest fixtures, besides simplifying the
creation of Flask apps we can also pass config overrides to the app, so
we can test multiple cases without creating different apps.

We can now also run the tests with `python setup.py test`, which will
install the test requirements before running them.

Unit tests require SQL ALchemy to run, so they're now installed before
they're executed; `pip install .[tests]` should also install them manually.