### PR TITLE
Add tox-travis integration support, added py34 and py35 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 sudo: false
+
 language: python
-python: "3.6"
-env:
-  - TOXENV=py27
-  - TOXENV=py36
+
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+cache:
+  - apt
+  - pip
+
 install:
-  - pip install tox
+  - pip install tox tox-travis
+
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,stylecheck
+envlist = py27,py34,py35,py36,stylecheck
 
 [testenv]
 deps =


### PR DESCRIPTION
With tox-travis, the correct python version is displayed in Travis.