### PR TITLE
Don't use POST method for sql_select/explain

### DIFF
--- a/flask_debugtoolbar/panels/sqlalchemy.py
+++ b/flask_debugtoolbar/panels/sqlalchemy.py
@@ -128,8 +128,8 @@ class SQLAlchemyDebugPanel(DebugPanel):
 # Panel views
 
 
-@module.route('/sqlalchemy/sql_select', methods=['GET', 'POST'])
-@module.route('/sqlalchemy/sql_explain', methods=['GET', 'POST'],
+@module.route('/sqlalchemy/sql_select', methods=['GET'])
+@module.route('/sqlalchemy/sql_explain', methods=['GET'],
               defaults=dict(explain=True))
 def sql_select(explain=False):
     statement, params = load_query(request.args['query'])

--- a/flask_debugtoolbar/static/js/toolbar.js
+++ b/flask_debugtoolbar/static/js/toolbar.js
@@ -58,7 +58,7 @@
         return false;
       });
       $('#flDebug a.remoteCall').click(function() {
-        $('#flDebugWindow').load(this.href, {}, function() {
+        $('#flDebugWindow').load(this.href, function() {
           $('#flDebugWindow a.flDebugBack').click(function() {
             $(this).parent().parent().hide();
             return false;


### PR DESCRIPTION
I've installed the debug toolbar on my application and it works well. Thanks.

But because I was using `Flask_WTF` with `CSRF` protection, I was receiving `400 Bad Request` errors each time I was clicking on the `SELECT` or `EXPLAIN` link in the `SQLAlchemy` panel.
Of course, I found a proper way to handle this with better configuration of the `CSRF` protection in my app.

However I don't think that we need to use the `POST` method for the `sql_select` or `sql_explain` routes.

This pull request makes sure that we only accept `GET` and that the browser uses the correct method to call the service (using JQuery load method).