### PR TITLE
[Fix] fix issue: #132

### DIFF
--- a/flask_debugtoolbar/panels/versions.py
+++ b/flask_debugtoolbar/panels/versions.py
@@ -9,7 +9,10 @@ _ = lambda x: x
 
 def relpath(location, python_lib):
     location = os.path.normpath(location)
-    relative = os.path.relpath(location, python_lib)
+    try:
+        relative = os.path.relpath(location, python_lib)
+    except ValueError:
+        return ''
     if relative == os.path.curdir:
         return ''
     elif relative.startswith(os.path.pardir):


### PR DESCRIPTION
issue #132:
Under Windows, relpath can't get a relative path to a path in **different volume**.
If there is a package installed in a volume different from where python is installed. debugtoolbar crashes.

How to reproduce:
1. Windows
2. install python in ```c:\python```
3. git clone any package such as ```https://github.com/mgood/flask-debugtoolbar``` into ```d:\```, than use ```pip install -e .``` to install it.
4. run flask with debug toolbar.
5. crash!