### PR TITLE
Fix: ValueError: path is on mount 'D:'... #129

### DIFF
--- a/flask_debugtoolbar/panels/versions.py
+++ b/flask_debugtoolbar/panels/versions.py
@@ -9,7 +9,11 @@ _ = lambda x: x
 
 def relpath(location, python_lib):
     location = os.path.normpath(location)
-    relative = os.path.relpath(location, python_lib)
+    try:
+        relative = os.path.relpath(location, python_lib)
+    except ValueError as e:
+        return location
+    
     if relative == os.path.curdir:
         return ''
     elif relative.startswith(os.path.pardir):


### PR DESCRIPTION
Fix: ValueError: path is on mount 'D:', start on mount 'C:' #129
this occurs when working in virtualenv on seperated drive