### PR TITLE
Point URLs at `pallets-eco/flask-debugtoolbar`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,9 @@ description = A toolbar overlay for debugging Flask applications.
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 keywords = flask, debug, toolbar
-url = https://github.com/flask-debugtoolbar/flask-debugtoolbar
+url = https://github.com/pallets-eco/flask-debugtoolbar
 project_urls =
-    Changelog = https://github.com/flask-debugtoolbar/flask-debugtoolbar/blob/master/CHANGES.rst
+    Changelog = https://github.com/pallets-eco/flask-debugtoolbar/blob/master/CHANGES.rst
     Documentation = https://flask-debugtoolbar.readthedocs.io/
 classifiers =
     Development Status :: 4 - Beta


### PR DESCRIPTION
These should have been fixed when we migrated the repo to `pallets-eco` org.