### PR TITLE
Add option to dump profiler stats

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,8 @@ Name                                  Description                             De
 ``DEBUG_TB_PANELS``                   List of module/class names of panels    enable all built-in panels
 ``DEBUG_TB_PROFILER_ENABLED``         Enable the profiler on all requests     ``False``, user-enabled
 ``DEBUG_TB_TEMPLATE_EDITOR_ENABLED``  Enable the template editor              ``False``
+``DEBUG_TB_PROFILER_DUMP_FILENAME``   Filename of the profiler stats dump,    ``None``, no dump will be written
+                                      can be a ``str`` or a ``callable``
 ====================================  =====================================   ==========================
 
 To change one of the config options, set it in the Flask app's config like::

--- a/src/flask_debugtoolbar/panels/profiler.py
+++ b/src/flask_debugtoolbar/panels/profiler.py
@@ -92,14 +92,14 @@ class ProfilerDebugPanel(DebugPanel):
 
             self.stats = stats
             self.function_calls = function_calls
-            
+
             if self.dump_filename:
                 if callable(self.dump_filename):
                     filename = self.dump_filename()
                 else:
                     filename = self.dump_filename
                 self.profiler.dump_stats(filename)
-        
+
         return response
 
     def title(self):

--- a/src/flask_debugtoolbar/panels/profiler.py
+++ b/src/flask_debugtoolbar/panels/profiler.py
@@ -14,6 +14,7 @@ class ProfilerDebugPanel(DebugPanel):
     """
     Panel that displays the time a response took with cProfile output.
     """
+
     name = 'Profiler'
 
     user_activate = True
@@ -22,6 +23,9 @@ class ProfilerDebugPanel(DebugPanel):
         DebugPanel.__init__(self, jinja_env, context=context)
         if current_app.config.get('DEBUG_TB_PROFILER_ENABLED'):
             self.is_active = True
+            self.dump_filename = current_app.config.get(
+                "DEBUG_TB_PROFILER_DUMP_FILENAME"
+            )
 
     def has_content(self):
         return bool(self.profiler)
@@ -88,7 +92,14 @@ class ProfilerDebugPanel(DebugPanel):
 
             self.stats = stats
             self.function_calls = function_calls
-            # destroy the profiler just in case
+            
+            if self.dump_filename:
+                if callable(self.dump_filename):
+                    filename = self.dump_filename()
+                else:
+                    filename = self.dump_filename
+                self.profiler.dump_stats(filename)
+        
         return response
 
     def title(self):


### PR DESCRIPTION
Add a config option `DEBUG_TB_PROFILER_DUMP_FILENAME` to dump profile stats to a file, so they can be further evaluated, e.g. with `flameprof`.