### PR TITLE
fix: drop response.charset because charset deprecated

### DIFF
--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -231,9 +231,9 @@ class DebugToolbarExtension(object):
             return response
 
         if 'gzip' in response.headers.get('Content-Encoding', ''):
-            response_html = gzip_decompress(response.data).decode(response.charset)
+            response_html = gzip_decompress(response.data).decode()
         else:
-            response_html = response.data.decode(response.charset)
+            response_html = response.get_data(as_text=True)
 
         no_case = response_html.lower()
         body_end = no_case.rfind('</body>')


### PR DESCRIPTION
next release of Werkzeug will drop response.charset.

    DeprecationWarning: The 'charset' attribute is deprecated and will not be used in Werkzeug 2.4. Text in body and cookie data will always use UTF-8.
