### PR TITLE
No need to specify custom default value if key not found

### DIFF
--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -230,7 +230,7 @@ class DebugToolbarExtension(object):
                 response.headers['content-type'].startswith('text/html')):
             return response
 
-        if 'gzip' in response.headers.get('Content-Encoding', ''):
+        if 'gzip' in response.headers.get('Content-Encoding'):
             response_html = gzip_decompress(response.data).decode()
         else:
             response_html = response.get_data(as_text=True)
@@ -258,7 +258,7 @@ class DebugToolbarExtension(object):
 
         content = ''.join((before, toolbar_html, after))
         content = content.encode(response.charset)
-        if 'gzip' in response.headers.get('Content-Encoding', ''):
+        if 'gzip' in response.headers.get('Content-Encoding'):
             content = gzip_compress(content)
         response.response = [content]
         response.content_length = len(content)


### PR DESCRIPTION
The `''` arg specifies a custom default value if the key isn't found. However, the default of `None` works fine for boolean testing:

```python
>>> 'gzip' in [None]
False
```

I missed this when I originally reviewed https://github.com/pallets-eco/flask-debugtoolbar/pull/154.