### PR TITLE
Remove deprecated charset property from process_response content crafting

### DIFF
--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -257,7 +257,7 @@ class DebugToolbarExtension(object):
         toolbar_html = toolbar.render_toolbar()
 
         content = ''.join((before, toolbar_html, after))
-        content = content.encode(response.charset)
+        content = content.encode('utf-8')
         if 'gzip' in response.headers.get('Content-Encoding', ''):
             content = gzip_compress(content)
         response.response = [content]


### PR DESCRIPTION
The `Request.charset` property is deprecated since Werkzeug version 2.3. It was removed in Werkzeug 3.0. Request data must always be UTF-8.

https://werkzeug.palletsprojects.com/en/2.3.x/wrappers/#werkzeug.wrappers.Request.charset