### PR TITLE
Remove usage of response.charset since it has been deprecated in werkzeug 3.0

### DIFF
--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -257,7 +257,7 @@ class DebugToolbarExtension(object):
         toolbar_html = toolbar.render_toolbar()
 
         content = ''.join((before, toolbar_html, after))
-        content = content.encode(response.charset)
+        content = content.encode('utf-8')
         if 'gzip' in response.headers.get('Content-Encoding', ''):
             content = gzip_compress(content)
         response.response = [content]


### PR DESCRIPTION
See patch https://github.com/pallets/werkzeug/commit/5ff0a573f4b78d9724f1f063fb058fd6bc76b24d#diff-b1e86a2597adb8762dd9e8318375db23db2005b2a44dd8298a0c5d973197672aL67

looks like the new contract is to always use utf-8:

>             "The 'charset' attribute is deprecated and will not be used in Werkzeug"
>             " 2.4. Interpreting bytes as text in body, form, and cookie data will"
>             " always use UTF-8.",

