### PR TITLE
Set up GitHub actions to replace Travis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '*.rst'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '*.rst'
+jobs:
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {name: Linux, python: '3.11', os: ubuntu-latest, tox: py311}
+          - {name: Windows, python: '3.11', os: windows-latest, tox: py311}
+          - {name: Mac, python: '3.11', os: macos-latest, tox: py311}
+          - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
+          - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
+          - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
+          - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
+          - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
+          - {name: '2.7', python: '2.7', os: ubuntu-latest, tox: py27}
+          - {name: Style, python: '3.10', os: ubuntu-latest, tox: stylecheck}
+    steps:
+      - uses: actions/checkout@v4
+      - name: update pip
+        run: |
+          pip install -U wheel
+          pip install -U setuptools
+          python -m pip install -U pip
+      - run: pip install tox
+      - run: tox -e ${{ matrix.tox }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: python
-python: "3.8"
-env:
-  - TOXENV=py27
-  - TOXENV=py38
-install:
-  - pip install tox
-script: tox

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ Flask Debug-toolbar
 This is a port of the excellent `django-debug-toolbar <https://github.com/jazzband/django-debug-toolbar>`_
 for Flask applications.
 
-.. image:: https://travis-ci.org/flask-debugtoolbar/flask-debugtoolbar.png?branch=master
-   :target: https://travis-ci.org/flask-debugtoolbar/flask-debugtoolbar
+.. image:: https://github.com/pallets-eco/flask-debugtoolbar/actions/workflows/tests.yml/badge.svg
+   :target: https://github.com/pallets-eco/flask-debugtoolbar/actions
 
 
 Installation

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38,stylecheck
+envlist = py27,py36,py37,py38,py39,py310,py311,stylecheck
 
 [testenv]
 deps =


### PR DESCRIPTION
fixes #190 

* Enable GitHub Actions
* Test against Python 2.7, 3.6~3.11
* Update the build badge
* Remove Travis config

The tests can be triggered normally:

https://github.com/greyli/flask-debugtoolbar/pull/1

![image](https://github.com/pallets-eco/flask-debugtoolbar/assets/12967000/96ac78d6-b4f6-4403-85c0-a046399128a7)
