### PR TITLE
Fix unit test and lint issues

### DIFF
--- a/example/app.py
+++ b/example/app.py
@@ -22,15 +22,13 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'
 db = SQLAlchemy(app)
 toolbar = DebugToolbarExtension(app)
 
+with app.app_context():
+    db.create_all()
+
 
 class ExampleModel(db.Model):
     __tablename__ = 'examples'
     value = db.Column(db.String(100), primary_key=True)
-
-
-@app.before_first_request
-def setup():
-    db.create_all()
 
 
 @app.route('/')

--- a/src/flask_debugtoolbar/panels/profiler.py
+++ b/src/flask_debugtoolbar/panels/profiler.py
@@ -94,7 +94,7 @@ class ProfilerDebugPanel(DebugPanel):
     def title(self):
         if not self.is_active:
             return "Profiler not active"
-        return 'View: %.2fms' % (float(self.stats.total_tt)*1000,)
+        return 'View: %.2fms' % (float(self.stats.total_tt) * 1000,)
 
     def nav_title(self):
         return 'Profiler'
@@ -102,7 +102,7 @@ class ProfilerDebugPanel(DebugPanel):
     def nav_subtitle(self):
         if not self.is_active:
             return "in-active"
-        return 'View: %.2fms' % (float(self.stats.total_tt)*1000,)
+        return 'View: %.2fms' % (float(self.stats.total_tt) * 1000,)
 
     def url(self):
         return ''

--- a/src/flask_debugtoolbar/utils.py
+++ b/src/flask_debugtoolbar/utils.py
@@ -88,6 +88,7 @@ def format_sql(query, args):
         SqlLexer(),
         HtmlFormatter(noclasses=True, style=PYGMENT_STYLE)))
 
+
 def gzip_compress(data, compresslevel=6):
     buff = io.BytesIO()
     with gzip.GzipFile(fileobj=buff, mode='wb', compresslevel=compresslevel) as f:

--- a/test/basic_app.py
+++ b/test/basic_app.py
@@ -4,10 +4,12 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_debugtoolbar import DebugToolbarExtension
 
 app = Flask('basic_app')
+app.config['DEBUG'] = True
 app.config['SECRET_KEY'] = 'abc123'
 app.config['SQLALCHEMY_RECORD_QUERIES'] = True
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'
-# This is no longer needed for Flask-SQLAlchemy 3.0+, if you're using 2.X you'll want to define this:
+# This is no longer needed for Flask-SQLAlchemy 3.0+,
+# if you're using 2.X you'll want to define this:
 # app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 # make sure these are printable in the config panel
@@ -17,15 +19,13 @@ app.config['UNICODE_VALUE'] = u'\uffff'
 toolbar = DebugToolbarExtension(app)
 db = SQLAlchemy(app)
 
+with app.app_context():
+    db.create_all()
+
 
 class Foo(db.Model):
     __tablename__ = 'foo'
     id = db.Column(db.Integer, primary_key=True)
-
-
-@app.before_first_request
-def setup():
-    db.create_all()
 
 
 @app.route('/')

--- a/test/test_toolbar.py
+++ b/test/test_toolbar.py
@@ -7,7 +7,6 @@ from flask_debugtoolbar import _printable
 
 def load_app(name):
     app = __import__(name).app
-    app.config['TESTING'] = True
     return app.test_client()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
 deps =
     pycodestyle
 commands =
-    pycodestyle flask_debugtoolbar test
+    pycodestyle src/flask_debugtoolbar test --ignore=E731,W503,W504
 
 [pycodestyle]
 max-line-length = 100


### PR DESCRIPTION
* Remove `before_first_request` as it has been removed in Flask 3.0.
* Fix lint issues
* Update the test app to use `DEBUG` as Flask-DebugToolbar will only be enabled when `app.debug` is `True` (https://github.com/pallets-eco/flask-debugtoolbar/blob/51d105afadda04a32231b1481c68ac7c0104aebf/src/flask_debugtoolbar/__init__.py#L114)