### PR TITLE
Fix tox and GitHub actions settings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: '3.6', python: '3.6', os: ubuntu-20.04, tox: py36}
+          - {name: '3.6', python: '3.6', os: ubuntu-20.04, tox: py36}  # ubuntu-latest doesn't support 3.6
           - {name: Style, python: '3.10', os: ubuntu-latest, tox: stylecheck}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,6 @@ on:
       - 'docs/**'
       - '*.rst'
   pull_request:
-    branches:
-      - master
     paths-ignore:
       - 'docs/**'
       - '*.rst'
@@ -20,22 +18,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.11', os: ubuntu-latest, tox: py311}
-          - {name: Windows, python: '3.11', os: windows-latest, tox: py311}
-          - {name: Mac, python: '3.11', os: macos-latest, tox: py311}
+          - {name: Linux, python: '3.12', os: ubuntu-latest, tox: py312}
+          - {name: Windows, python: '3.12', os: windows-latest, tox: py312}
+          - {name: Mac, python: '3.12', os: macos-latest, tox: py312}
+          - {name: '3.11', python: '3.11', os: ubuntu-latest, tox: py311}
           - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
-          - {name: '2.7', python: '2.7', os: ubuntu-latest, tox: py27}
+          - {name: '3.6', python: '3.6', os: ubuntu-20.04, tox: py36}
           - {name: Style, python: '3.10', os: ubuntu-latest, tox: stylecheck}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
       - name: update pip
         run: |
-          pip install -U wheel
-          pip install -U setuptools
+          pip install -U setuptools wheel
           python -m pip install -U pip
       - run: pip install tox
       - run: tox -e ${{ matrix.tox }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,py310,py311,stylecheck
+envlist =
+    py27
+    py3{12,11,10,9,8,7,6}
+    stylecheck
+skip_missing_interpreters = True
 
 [testenv]
 deps =


### PR DESCRIPTION
* Remove the branch constraint for pull request triggering
* Use Python 3.12 for main tests
* Use `ubuntu-20.04` for Python 3.6 since it's been removed in `ubuntu-latest`
* Remove Python 2.7 since it's not supported by GitHub Actions anymore (https://github.com/actions/setup-python/issues/672)
* Add the missing `setup-python` step
* Merge the `pip install` commands