### PR TITLE
Fix the test for basic app

### DIFF
--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -230,7 +230,8 @@ class DebugToolbarExtension(object):
                 response.headers['content-type'].startswith('text/html')):
             return response
 
-        if 'gzip' in response.headers.get('Content-Encoding'):
+        content_encoding = response.headers.get('Content-Encoding')
+        if content_encoding and 'gzip' in content_encoding:
             response_html = gzip_decompress(response.data).decode()
         else:
             response_html = response.get_data(as_text=True)
@@ -258,7 +259,7 @@ class DebugToolbarExtension(object):
 
         content = ''.join((before, toolbar_html, after))
         content = content.encode('utf-8')
-        if 'gzip' in response.headers.get('Content-Encoding'):
+        if content_encoding and 'gzip' in content_encoding:
             content = gzip_compress(content)
         response.response = [content]
         response.content_length = len(content)

--- a/test/basic_app.py
+++ b/test/basic_app.py
@@ -4,6 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_debugtoolbar import DebugToolbarExtension
 
 app = Flask('basic_app')
+app.config['DEBUG'] = True
 app.config['SECRET_KEY'] = 'abc123'
 app.config['SQLALCHEMY_RECORD_QUERIES'] = True
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'


### PR DESCRIPTION
1. Update the test app

If I understand correctly, the debug toolbar will only be enabled if `app.debug` is `True`. So I added the `DEBUG=True` to the test app.

Related code: https://github.com/pallets-eco/flask-debugtoolbar/blob/2b8bf9cc449a95f442b99dfdfb6147fa1ae2230a/src/flask_debugtoolbar/__init__.py#L114

2. Update the `src/flask_debugtoolbar/__init__.py`

Fix the two if statements to prevent the following errors:

```
>       if 'gzip' in response.headers.get('Content-Encoding'):
E       TypeError: argument of type 'NoneType' is not iterable
```

Since the `response.headers.get('Content-Encoding')` could be None.

With this PR, all the tests will be passed. The failed style checker will be fixed in #219 