### PR TITLE
Require Flask >= 2.2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: '3.6', python: '3.6', os: ubuntu-20.04, tox: py36}  # ubuntu-latest doesn't support 3.6
           - {name: Style, python: '3.10', os: ubuntu-latest, tox: stylecheck}
     steps:
       - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
 
 packages = find:
 include_package_data = True
-python_requires = >=2.7
+python_requires = >=3.7
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="Flask-DebugToolbar",
     install_requires=[
-        'Flask>=0.8',
+        'Flask>=2.2.0',
         'Blinker',
         'itsdangerous',
         'werkzeug',

--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -3,15 +3,8 @@ import urllib.parse
 import warnings
 
 import flask
-from packaging import version as version_builder
 from flask import Blueprint, current_app, request, g, send_from_directory, url_for
-
-
-if version_builder.parse(flask.__version__) >= version_builder.parse("2.2.0"):
-    from flask.globals import request_ctx
-else:
-    from flask.globals import _request_ctx_stack
-
+from flask.globals import request_ctx
 
 from jinja2 import __version__ as __jinja_version__
 from jinja2 import Environment, PackageLoader
@@ -132,11 +125,7 @@ class DebugToolbarExtension(object):
 
     def dispatch_request(self):
         """Modified version of Flask.dispatch_request to call process_view."""
-        if version_builder.parse(flask.__version__) >= version_builder.parse("2.2.0"):
-            req = request_ctx.request
-        else:
-            req = _request_ctx_stack.top.request
-
+        req = request_ctx.request
         app = current_app
 
         if req.routing_exception is not None:

--- a/test/test_toolbar.py
+++ b/test/test_toolbar.py
@@ -1,7 +1,5 @@
 import sys
 
-import pytest
-
 from flask_debugtoolbar import _printable
 
 
@@ -16,26 +14,3 @@ def test_basic_app():
     index = app.get('/')
     assert index.status_code == 200
     assert b'<div id="flDebug"' in index.data
-
-
-@pytest.mark.skipif(sys.version_info >= (3,),
-                    reason='test only applies to Python 2')
-def test_printable_unicode():
-    class UnicodeRepr(object):
-        def __repr__(self):
-            return u'\uffff'
-
-    printable = _printable(UnicodeRepr())
-    assert "raised UnicodeEncodeError: 'ascii' codec" in printable
-
-
-@pytest.mark.skipif(sys.version_info >= (3,),
-                    reason='test only applies to Python 2')
-def test_printable_non_ascii():
-    class NonAsciiRepr(object):
-        def __repr__(self):
-            return 'a\xffb'
-
-    printable = u'%s' % _printable(NonAsciiRepr())
-    # should replace \xff with the unicode ? character
-    assert printable == u'a\ufffdb'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py27
-    py3{12,11,10,9,8,7,6}
+    py3{12,11,10,9,8,7}
     stylecheck
     minimal
 skip_missing_interpreters = True


### PR DESCRIPTION
Require Flask >= `2.2.0`.

I'm comfortable going up to requiring `3.x`, but when I grep'd for
places we use older Flask constructs, this was all I found.

So for now no need to jump further.

Flask `2.2.0` requires Python >= `3.7`, so also dropped older pythons.

I also dropped the Python 3.6 test from being required on the repo branch settings.

Fix https://github.com/pallets-eco/flask-debugtoolbar/issues/222