### PR TITLE
Add the missing install requirement `packaging`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
         'itsdangerous',
         'werkzeug',
         'MarkupSafe',
+        'packaging',
     ],
 )


### PR DESCRIPTION
The `packaging` lib is not listed in the `install_requires` list.

https://github.com/greyli/flask-extension-status/actions/runs/7129071225/job/19412328108

We need to merge this and then make a fix release ASAP.