### PR TITLE
Bump to version `0.14.1`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Flask-DebugToolbar
-version = 0.14.0
+version = 0.14.1
 author = Michael van Tellingen
 author_email = michaelvantellingen@gmail.com
 maintainer = Matt Good


### PR DESCRIPTION
We need a `0.14.1` release which will include the bugfix https://github.com/pallets-eco/flask-debugtoolbar/pull/225.