### PR TITLE
Add minimal test without extra deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           - {name: Linux, python: '3.12', os: ubuntu-latest, tox: py312}
           - {name: Windows, python: '3.12', os: windows-latest, tox: py312}
           - {name: Mac, python: '3.12', os: macos-latest, tox: py312}
+          - {name: Minimal, python: '3.12', os: ubuntu-latest, tox: minimal}
           - {name: '3.11', python: '3.11', os: ubuntu-latest, tox: py311}
           - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py27
     py3{12,11,10,9,8,7,6}
     stylecheck
+    minimal
 skip_missing_interpreters = True
 
 [testenv]
@@ -12,6 +13,12 @@ deps =
     Pygments
 commands =
     pytest
+
+[testenv:minimal]
+deps =
+    .
+commands =
+    python -c "from flask_debugtoolbar import DebugToolbarExtension"
 
 [testenv:stylecheck]
 deps =


### PR DESCRIPTION
To prevent issues like https://github.com/pallets-eco/flask-debugtoolbar/pull/225, This PR add a minimal test that no extra deps are involved, it only install the package, then try to import the extension class.

fixes #226