### PR TITLE
Fix missing `distutils` error on Python 3.12

### DIFF
--- a/src/flask_debugtoolbar/panels/versions.py
+++ b/src/flask_debugtoolbar/panels/versions.py
@@ -1,5 +1,5 @@
 import os
-from distutils.sysconfig import get_python_lib
+from sysconfig import get_path
 
 from flask import __version__ as flask_version
 from flask_debugtoolbar.panels import DebugPanel
@@ -47,6 +47,6 @@ class VersionDebugPanel(DebugPanel):
 
         return self.render('panels/versions.html', {
             'packages': packages,
-            'python_lib': os.path.normpath(get_python_lib()),
+            'python_lib': os.path.normpath(get_path('platlib')),
             'relpath': relpath,
         })


### PR DESCRIPTION
Running on Python 3.12 I see:

```shell
[2024-04-11 11:01:12,915] WARNING in toolbar: Disabled flask_debugtoolbar.panels.versions.VersionDebugPanel due to ImportError: import_string() failed for 'flask_debugtoolbar.panels.versions.VersionDebugPanel'. Possible reasons are:

- missing __init__.py in a package;
- package or module path not included in sys.path;
- duplicated package or module name taking precedence in sys.path;
- missing module, class, function or variable;

Debugged import:

- 'flask_debugtoolbar' found in '/Users/jeffwidman/Code/open-source/flask-debugtoolbar/src/flask_debugtoolbar/__init__.py'.
- 'flask_debugtoolbar.panels' found in '/Users/jeffwidman/Code/open-source/flask-debugtoolbar/src/flask_debugtoolbar/panels/__init__.py'.
- 'flask_debugtoolbar.panels.versions' not found.

Original exception:

ModuleNotFoundError: No module named 'distutils'
```

This is because Python 3.12 removed `distutils`.

Fix pulled from https://bugs.python.org/issue41282#msg393018.

This will not work on Python `3.6`, but we've already dropped support for that.

After the fix, the error is gone and the Versions panel re-appears.