### PR TITLE
Remove deprecated Flask version attribute

### DIFF
--- a/src/flask_debugtoolbar/panels/versions.py
+++ b/src/flask_debugtoolbar/panels/versions.py
@@ -1,8 +1,18 @@
 import os
 from sysconfig import get_path
 
-from flask import __version__ as flask_version
 from flask_debugtoolbar.panels import DebugPanel
+
+try:
+    # Python 3.8+
+    from importlib.metadata import version
+
+    flask_version = version('flask')
+
+except ImportError:
+    import pkg_resources
+
+    flask_version = pkg_resources.get_distribution('flask').version
 
 _ = lambda x: x
 


### PR DESCRIPTION
The `flask.__version__` attr is deprecated and will be removed in the Flask 3.1 version. This PR replaced this attr to `importlib.metadata.version`.

We could remove the use of `pkg_resources` when we drop the Python 3.7 support.

Fix: https://github.com/pallets-eco/flask-debugtoolbar/issues/229