### PR TITLE
Migrate deps to `setup.cfg`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/_themes"]
-	path = docs/_themes
-	url = https://github.com/mitsuhiko/flask-sphinx-themes.git

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ BUILD_DATE = datetime.datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_
 extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
+    'pallets_sphinx_themes',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,23 @@ package_dir =
 packages = find:
 include_package_data = True
 python_requires = >=3.7
+install_requires =
+    Flask>=2.2.0
+    Blinker
+    itsdangerous
+    werkzeug
+    MarkupSafe
+    packaging
 
 [options.packages.find]
 where = src
+
+[options.extras_require]
+test =
+    pytest
+    Flask-SQLAlchemy
+    Pygments
+
+docs =
+    Sphinx>=1.2.2
+    Pallets-Sphinx-Themes

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,3 @@
 from setuptools import setup
 
-# Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
-setup(
-    name="Flask-DebugToolbar",
-    install_requires=[
-        'Flask>=2.2.0',
-        'Blinker',
-        'itsdangerous',
-        'werkzeug',
-        'MarkupSafe',
-        'packaging',
-    ],
-)
+setup()

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,14 @@ envlist =
 skip_missing_interpreters = True
 
 [testenv]
-deps =
-    pytest
-    Flask-SQLAlchemy
-    Pygments
+extras =
+    test
+
 commands =
     pytest
 
 [testenv:minimal]
+# test without extra deps to ensure package is buildable
 deps =
     .
 commands =


### PR DESCRIPTION
Modern python packaging uses `setup.cfg`. Historically we had our deps in `setup.py` due to GitHub's dependency graph, but they've since added support for parsing deps out of `setup.cfg`.

Also, this allows us to start specifying the Sphinx theme as a `docs` extra... this is much more idiomatic than bundling it as a git submodule. And will later make it much simpler for RTD etc to pull in the custom theme.