### PR TITLE
Drop unnecessary `Blinker` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ setup(
     name="Flask-DebugToolbar",
     install_requires=[
         'Flask>=2.2.0',
-        'Blinker',
         'itsdangerous',
         'werkzeug',
         'MarkupSafe',


### PR DESCRIPTION
Flask requires this, so it's a transitive dep, but it's not directly used within this toolbar at all.

We do directly import the other listed packages, so they should stay.