### PR TITLE
Install custom Sphinx theme via `extras_require`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/_themes"]
-	path = docs/_themes
-	url = https://github.com/mitsuhiko/flask-sphinx-themes.git

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ BUILD_DATE = datetime.datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_
 extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
+    'pallets_sphinx_themes',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -112,9 +113,7 @@ html_theme = 'flask'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    'index_logo': None,
-}
+html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 sys.path.append(os.path.abspath('_themes'))

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,10 @@ setup(
         'MarkupSafe',
         'packaging',
     ],
+     extras_require={
+        "docs": [
+            'Sphinx>=1.2.2',
+            'Pallets-Sphinx-Themes',
+        ],
+     }
 )


### PR DESCRIPTION
Previously the custom theme was vendored in via a `git` submodule...

Now this theme is available via a python package, so install it using `extras_require` instead.

This also unlocks letting other tooling such as ReadTheDocs install the custom theme without having to do custom git incantations.

I also removed the `index_logo` config as Sphinx warns that it's not a supported option by the theme. I grep'd the theme package, and it makes no mention of this option, besides we were leaving it blank already, so there's no point in having it.