### PR TITLE
Bump to `0.15.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Flask-DebugToolbar
-version = 0.14.1
+version = 0.15.0
 author = Michael van Tellingen
 author_email = michaelvantellingen@gmail.com
 maintainer = Matt Good


### PR DESCRIPTION
We've merged a number of deprecation fixes, let's get them live to our users via a new release.

Fix https://github.com/pallets-eco/flask-debugtoolbar/issues/244