### PR TITLE
drop python 3.7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,6 @@ jobs:
           - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
-          - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: Style, python: '3.10', os: ubuntu-latest, tox: stylecheck}
     steps:
       - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
 
 packages = find:
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 where = src

--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -1,29 +1,19 @@
 import contextvars
+import importlib.metadata
 import os
 import urllib.parse
 import warnings
 
-import flask
 from flask import Blueprint, current_app, request, g, send_from_directory, url_for
 from flask.globals import request_ctx
 
 from jinja2 import __version__ as __jinja_version__
 from jinja2 import Environment, PackageLoader
 
-from flask_debugtoolbar.compat import iteritems
 from flask_debugtoolbar.toolbar import DebugToolbar
 from flask_debugtoolbar.utils import decode_text, gzip_compress, gzip_decompress
 
-try:
-    # Python 3.8+
-    from importlib.metadata import version
-
-    __version__ = version("Flask-DebugToolbar")
-except ImportError:
-    import pkg_resources
-
-    __version__ = pkg_resources.get_distribution("Flask-DebugToolbar").version
-
+__version__ = importlib.metadata.version("flask-debugtoolbar")
 
 module = Blueprint('debugtoolbar', __name__)
 
@@ -80,7 +70,7 @@ class DebugToolbarExtension(object):
             self.init_app(app)
 
     def init_app(self, app):
-        for k, v in iteritems(self._default_config(app)):
+        for k, v in self._default_config(app).items():
             app.config.setdefault(k, v)
 
         if not app.config['DEBUG_TB_ENABLED']:

--- a/src/flask_debugtoolbar/compat.py
+++ b/src/flask_debugtoolbar/compat.py
@@ -1,9 +1,0 @@
-import sys
-
-PY2 = sys.version_info[0] == 2
-
-
-if PY2:
-    iteritems = lambda d: d.iteritems()
-else:
-    iteritems = lambda d: iter(d.items())

--- a/src/flask_debugtoolbar/panels/logger.py
+++ b/src/flask_debugtoolbar/panels/logger.py
@@ -2,10 +2,7 @@ from __future__ import with_statement
 
 import datetime
 import logging
-try:
-    import threading
-except ImportError:
-    threading = None
+import threading
 
 from flask_debugtoolbar.panels import DebugPanel
 from flask_debugtoolbar.utils import format_fname
@@ -15,9 +12,6 @@ _ = lambda x: x
 
 class ThreadTrackingHandler(logging.Handler):
     def __init__(self):
-        if threading is None:
-            raise NotImplementedError("threading module is not available, \
-                the logging panel cannot be used without it")
         logging.Handler.__init__(self)
         self.records = {}  # a dictionary that maps threads to log records
 
@@ -59,12 +53,9 @@ def _init_once():
         # and not configure console logging for the request log.
         # Werkzeug's default log level is INFO so this message probably won't
         # be seen.
-        try:
-            from werkzeug._internal import _log
-        except ImportError:
-            pass
-        else:
-            _log('debug', 'Initializing Flask-DebugToolbar log handler')
+        from werkzeug._internal import _log
+
+        _log('debug', 'Initializing Flask-DebugToolbar log handler')
 
         handler = ThreadTrackingHandler()
         logging.root.addHandler(handler)

--- a/src/flask_debugtoolbar/panels/versions.py
+++ b/src/flask_debugtoolbar/panels/versions.py
@@ -1,18 +1,10 @@
+import importlib.metadata
 import os
 from sysconfig import get_path
 
 from flask_debugtoolbar.panels import DebugPanel
 
-try:
-    # Python 3.8+
-    from importlib.metadata import version
-
-    flask_version = version('flask')
-
-except ImportError:
-    import pkg_resources
-
-    flask_version = pkg_resources.get_distribution('flask').version
+flask_version = importlib.metadata.version("flask")
 
 _ = lambda x: x
 
@@ -37,13 +29,8 @@ class VersionDebugPanel(DebugPanel):
         return _('Versions')
 
     def content(self):
-        try:
-            import importlib.metadata
-        except ImportError:
-            packages = []
-        else:
-            packages_metadata = [p.metadata for p in importlib.metadata.distributions()]
-            packages = sorted(packages_metadata, key=lambda p: p['Name'].lower())
+        packages_metadata = [p.metadata for p in importlib.metadata.distributions()]
+        packages = sorted(packages_metadata, key=lambda p: p['Name'].lower())
 
         return self.render('panels/versions.html', {
             'packages': packages,

--- a/src/flask_debugtoolbar/templates/panels/versions.html
+++ b/src/flask_debugtoolbar/templates/panels/versions.html
@@ -24,12 +24,6 @@
         <td>{{ package.get('Home-page') }}</td>
         <td>{{ package.get('Summary') }}</td>
       </tr>
-    {% else %}
-      <tr>
-        <td>Python 3.8</td>
-        <td>NOT INSTALLED</td>
-        <td>This panel requires Python >= 3.8 in order to display installed packages and version information.</td>
-      </tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/flask_debugtoolbar/toolbar.py
+++ b/src/flask_debugtoolbar/toolbar.py
@@ -1,7 +1,4 @@
-try:
-    from urllib.parse import unquote
-except ImportError:
-    from urllib import unquote
+from urllib.parse import unquote
 
 from flask import url_for, current_app
 from werkzeug.utils import import_string

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{12,11,10,9,8,7}
+    py3{12,11,10,9,8}
     stylecheck
     minimal
 skip_missing_interpreters = True


### PR DESCRIPTION
Python 3.7 is EOL. Set minimum version to 3.8, and remove compatibility code for lower versions.
