### PR TITLE
Bump `Flask` to `>=2.3.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="Flask-DebugToolbar",
     install_requires=[
-        'Flask>=2.2.0',
+        'Flask>=2.3.0',
         'itsdangerous',
         'werkzeug',
         'MarkupSafe',


### PR DESCRIPTION
Now that we've dropped support for Python `3.7`,
it probably makes sense to also bump our minimum
version of Flask to `2.3.0`, as that is when Flask
dropped support for Python `3.7`: https://flask.palletsprojects.com/en/3.0.x/changes/#version-2-3-0