### PR TITLE
remove `__version__`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Flask-DebugToolbar"
-version = "0.15.1"
+version = "0.16.0.dev"
 description = "A toolbar overlay for debugging Flask applications."
 readme = "README.md"
 license = { file = "LICENSE.txt" }

--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -297,19 +297,3 @@ class DebugToolbarExtension:
     def render(self, template_name: str, context: dict[str, t.Any]) -> str:
         template = self.jinja_env.get_template(template_name)
         return template.render(**context)
-
-
-def __getattr__(name: str) -> t.Any:
-    import warnings
-
-    if name == "__version__":
-        warnings.warn(
-            "The '__version__' attribute is deprecated and will be removed in"
-            " Flask-DebugToolbar 0.17. Use feature detection or"
-            " 'importlib.metadata.version(\"flask-debugtoolbar\")' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return importlib.metadata.version("flask-debugtoolbar")
-
-    raise AttributeError(name)

--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -27,7 +27,6 @@ from .utils import decode_text
 from .utils import gzip_compress
 from .utils import gzip_decompress
 
-__version__ = importlib.metadata.version("flask-debugtoolbar")
 _jinja_version = importlib.metadata.version("jinja2")
 
 module: Blueprint = Blueprint("debugtoolbar", __name__)
@@ -298,3 +297,19 @@ class DebugToolbarExtension:
     def render(self, template_name: str, context: dict[str, t.Any]) -> str:
         template = self.jinja_env.get_template(template_name)
         return template.render(**context)
+
+
+def __getattr__(name: str) -> t.Any:
+    import warnings
+
+    if name == "__version__":
+        warnings.warn(
+            "The '__version__' attribute is deprecated and will be removed in"
+            " Flask-DebugToolbar 0.17. Use feature detection or"
+            " 'importlib.metadata.version(\"flask-debugtoolbar\")' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return importlib.metadata.version("flask-debugtoolbar")
+
+    raise AttributeError(name)

--- a/src/flask_debugtoolbar/__init__.py
+++ b/src/flask_debugtoolbar/__init__.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import collections.abc as c
-import importlib.metadata
 import os
 import typing as t
 import urllib.parse
 import warnings
 from contextvars import ContextVar
 
+import jinja2.ext
 from flask import Blueprint
 from flask import current_app
 from flask import Flask
@@ -26,8 +26,6 @@ from .toolbar import DebugToolbar
 from .utils import decode_text
 from .utils import gzip_compress
 from .utils import gzip_decompress
-
-_jinja_version = importlib.metadata.version("jinja2")
 
 module: Blueprint = Blueprint("debugtoolbar", __name__)
 
@@ -66,10 +64,11 @@ class DebugToolbarExtension:
         self.debug_toolbars_var: ContextVar[dict[Request, DebugToolbar]] = ContextVar(
             "debug_toolbars"
         )
-        jinja_extensions = ["jinja2.ext.i18n"]
+        jinja_extensions = [jinja2.ext.i18n]
 
-        if _jinja_version[0] == "2":
-            jinja_extensions.append("jinja2.ext.with_")
+        # Jinja2<3
+        if hasattr(jinja2.ext, "with_"):
+            jinja_extensions.append(jinja2.ext.with_)  # pyright: ignore
 
         # Configure jinja for the internal templates and add url rules
         # for static data


### PR DESCRIPTION
The `__version__` attribute is an old pattern from early in Python packaging. Setuptools eventually made it easier to use the pattern by allowing reading the value from the attribute at build time, and some other build backends have done the same.

However, there's no reason to expose this directly in code anymore. It's usually easier to use feature detection (`hasattr`, `try/except`) instead. `importlib.metadata.version("flask-debugtoolbar")` can be used to get the version at runtime in a standard way, if it's really needed.

This matches what we've already done in the Pallets projects.
