### PR TITLE
Fix misnamed class attribute

### DIFF
--- a/src/flask_debugtoolbar/panels/__init__.py
+++ b/src/flask_debugtoolbar/panels/__init__.py
@@ -18,7 +18,7 @@ class DebugPanel:
     has_content = False
 
     # If the client is able to activate/de-activate the panel
-    user_enable = False
+    user_activate = False
 
     # We'll maintain a local context instance so we can expose our template
     # context variables to panels which need them:
@@ -62,8 +62,9 @@ class DebugPanel:
         template = self.jinja_env.get_template(template_name)
         return template.render(**context)
 
-    def dom_id(self) -> str:
-        return f"flDebug{self.name.replace(' ', '')}Panel"
+    @classmethod
+    def dom_id(cls) -> str:
+        return f"flDebug{cls.name.replace(' ', '')}Panel"
 
     def nav_title(self) -> str:
         """Title showing in toolbar"""

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import typing as t
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -8,6 +9,7 @@ import pytest
 from flask import Flask
 from flask import Response
 from flask.testing import FlaskClient
+from werkzeug.utils import import_string
 
 from flask_debugtoolbar import DebugToolbarExtension
 
@@ -165,3 +167,28 @@ def test_toolbar_serves_assets_based_on_host_configuration(
                 "/_debug_toolbar/static/js/toolbar.js", headers={"Host": request_host}
             )
             assert response.status_code == expected_status_code
+
+
+def test_debug_switch_included_for_user_activated_panels() -> None:
+    checked_panels = set()
+
+    app = load_app("basic_app")
+    index = app.get("/")
+    html = index.text
+
+    panels = app.application.config["DEBUG_TB_PANELS"]
+    for panel in panels:
+        panel_cls = import_string(panel)
+        panel_id = panel_cls.dom_id()
+
+        match = re.search(rf'<li id="{panel_id}">(.*?)</li>', html, re.DOTALL)
+        assert match, f"Panel {panel_id} not found in the rendered toolbar"
+
+        has_switch = "flDebugSwitch" in match.group(1)
+        assert (
+            has_switch is panel_cls.user_activate
+        ), f"Panel {panel_id} is incorrectly showing (or not showing) a debug switch"
+
+        checked_panels.add(panel_id)
+
+    assert len(checked_panels) == len(panels)


### PR DESCRIPTION
While scanning the code I noticed that there's a mismatched class attribute. On the base class it's `user_enable`, but on the subclasses and when checking in the template, it's `user_activate`. This patch is primarily focused on just fixing that simple typo - and adding tests that actually validate the attribute is doing what it claims to do (at least in so far as adding some HTML; it doesn't test functionality).

The `@classmethod` change may not be desirable and I'd gladly take a suggestion on how to get the dom ID without needing an instantiated class. May just be fine to build the ID again in the test, but that's obviously a little more brittle. Possibly also one you may consider a breaking change?

And I appreciate that it's a chunk of requirements changes for adding one more test, but they make querying the HTML for the elements under test a lot simpler, so hopefully it's not an issue.