### PR TITLE
Jquery update

### DIFF
--- a/src/flask_debugtoolbar/static/js/jquery.tablesorter.js
+++ b/src/flask_debugtoolbar/static/js/jquery.tablesorter.js
@@ -1,6 +1,7 @@
-/*! TableSorter (FORK) v2.31.3 *//*
+(function(factory){if (typeof define === 'function' && define.amd){define(['jquery'], factory);} else if (typeof module === 'object' && typeof module.exports === 'object'){module.exports = factory(require('jquery'));} else {factory(jQuery);}}(function(jQuery){
+/*! TableSorter (FORK) v2.32.0 *//*
 * Client-side table sorting with ease!
-* @requires jQuery v1.2.6+
+* @requires jQuery v3.5+
 *
 * Copyright (c) 2007 Christian Bach
 * fork maintained by Rob Garrison
@@ -22,7 +23,7 @@
 	'use strict';
 	var ts = $.tablesorter = {
 
-		version : '2.31.3',
+		version : '2.32.0',
 
 		parsers : [],
 		widgets : [],
@@ -49,7 +50,7 @@
 			resort           : true,       // default setting to trigger a resort after an 'update', 'addRows', 'updateCell', etc has completed
 
 			// *** sort options
-			headers          : {},         // set sorter, string, empty, locked order, sortInitialOrder, filter, etc.
+			headers          : null,       // set sorter, string, empty, locked order, sortInitialOrder, filter, etc.
 			ignoreCase       : true,       // ignore case while sorting
 			sortForce        : null,       // column(s) first sorted; always applied
 			sortList         : [],         // Initial sort order; applied initially; updated when manually sorted
@@ -333,8 +334,8 @@
 			// show processesing icon
 			if ( c.showProcessing ) {
 				$table
-				.unbind( 'sortBegin' + c.namespace + ' sortEnd' + c.namespace )
-				.bind( 'sortBegin' + c.namespace + ' sortEnd' + c.namespace, function( e ) {
+				.off( 'sortBegin' + c.namespace + ' sortEnd' + c.namespace )
+				.on( 'sortBegin' + c.namespace + ' sortEnd' + c.namespace, function( e ) {
 					clearTimeout( c.timerProcessing );
 					ts.isProcessing( table );
 					if ( e.type === 'sortBegin' ) {
@@ -367,8 +368,8 @@
 					.join( namespace + ' ' );
 			// apply easy methods that trigger bound events
 			$table
-			.unbind( events.replace( ts.regex.spaces, ' ' ) )
-			.bind( 'sortReset' + namespace, function( e, callback ) {
+			.off( events.replace( ts.regex.spaces, ' ' ) )
+			.on( 'sortReset' + namespace, function( e, callback ) {
 				e.stopPropagation();
 				// using this.config to ensure functions are getting a non-cached version of the config
 				ts.sortReset( this.config, function( table ) {
@@ -383,67 +384,67 @@
 					}
 				});
 			})
-			.bind( 'updateAll' + namespace, function( e, resort, callback ) {
+			.on( 'updateAll' + namespace, function( e, resort, callback ) {
 				e.stopPropagation();
 				ts.updateAll( this.config, resort, callback );
 			})
-			.bind( 'update' + namespace + ' updateRows' + namespace, function( e, resort, callback ) {
+			.on( 'update' + namespace + ' updateRows' + namespace, function( e, resort, callback ) {
 				e.stopPropagation();
 				ts.update( this.config, resort, callback );
 			})
-			.bind( 'updateHeaders' + namespace, function( e, callback ) {
+			.on( 'updateHeaders' + namespace, function( e, callback ) {
 				e.stopPropagation();
 				ts.updateHeaders( this.config, callback );
 			})
-			.bind( 'updateCell' + namespace, function( e, cell, resort, callback ) {
+			.on( 'updateCell' + namespace, function( e, cell, resort, callback ) {
 				e.stopPropagation();
 				ts.updateCell( this.config, cell, resort, callback );
 			})
-			.bind( 'addRows' + namespace, function( e, $row, resort, callback ) {
+			.on( 'addRows' + namespace, function( e, $row, resort, callback ) {
 				e.stopPropagation();
 				ts.addRows( this.config, $row, resort, callback );
 			})
-			.bind( 'updateComplete' + namespace, function() {
+			.on( 'updateComplete' + namespace, function() {
 				this.isUpdating = false;
 			})
-			.bind( 'sorton' + namespace, function( e, list, callback, init ) {
+			.on( 'sorton' + namespace, function( e, list, callback, init ) {
 				e.stopPropagation();
 				ts.sortOn( this.config, list, callback, init );
 			})
-			.bind( 'appendCache' + namespace, function( e, callback, init ) {
+			.on( 'appendCache' + namespace, function( e, callback, init ) {
 				e.stopPropagation();
 				ts.appendCache( this.config, init );
-				if ( $.isFunction( callback ) ) {
+				if ( typeof callback === 'function' ) {
 					callback( this );
 				}
 			})
 			// $tbodies variable is used by the tbody sorting widget
-			.bind( 'updateCache' + namespace, function( e, callback, $tbodies ) {
+			.on( 'updateCache' + namespace, function( e, callback, $tbodies ) {
 				e.stopPropagation();
 				ts.updateCache( this.config, callback, $tbodies );
 			})
-			.bind( 'applyWidgetId' + namespace, function( e, id ) {
+			.on( 'applyWidgetId' + namespace, function( e, id ) {
 				e.stopPropagation();
 				ts.applyWidgetId( this, id );
 			})
-			.bind( 'applyWidgets' + namespace, function( e, callback ) {
+			.on( 'applyWidgets' + namespace, function( e, callback ) {
 				e.stopPropagation();
 				// apply widgets (false = not initializing)
 				ts.applyWidget( this, false, callback );
 			})
-			.bind( 'refreshWidgets' + namespace, function( e, all, dontapply ) {
+			.on( 'refreshWidgets' + namespace, function( e, all, dontapply ) {
 				e.stopPropagation();
 				ts.refreshWidgets( this, all, dontapply );
 			})
-			.bind( 'removeWidget' + namespace, function( e, name, refreshing ) {
+			.on( 'removeWidget' + namespace, function( e, name, refreshing ) {
 				e.stopPropagation();
 				ts.removeWidget( this, name, refreshing );
 			})
-			.bind( 'destroy' + namespace, function( e, removeClasses, callback ) {
+			.on( 'destroy' + namespace, function( e, removeClasses, callback ) {
 				e.stopPropagation();
 				ts.destroy( this, removeClasses, callback );
 			})
-			.bind( 'resetToLoadState' + namespace, function( e ) {
+			.on( 'resetToLoadState' + namespace, function( e ) {
 				e.stopPropagation();
 				// remove all widgets
 				ts.removeWidget( this, true, false );
@@ -480,8 +481,8 @@
 			// http://stackoverflow.com/questions/5312849/jquery-find-self;
 			.find( c.selectorSort )
 			.add( $headers.filter( c.selectorSort ) )
-			.unbind( tmp )
-			.bind( tmp, function( e, external ) {
+			.off( tmp )
+			.on( tmp, function( e, external ) {
 				var $cell, cell, temp,
 					$target = $( e.target ),
 					// wrap event type in spaces, so the match doesn't trigger on inner words
@@ -533,7 +534,7 @@
 				// cancel selection
 				$headers
 					.attr( 'unselectable', 'on' )
-					.bind( 'selectstart', false )
+					.on( 'selectstart', false )
 					.css({
 						'user-select' : 'none',
 						'MozUserSelect' : 'none' // not needed for jQuery 1.8+
@@ -829,18 +830,18 @@
 				// check data-attribute first when set to 'basic'; don't use node.innerText - it's really slow!
 				// http://www.kellegous.com/j/2013/02/27/innertext-vs-textcontent/
 				if ( extract === 'basic' && typeof ( tmp = $node.attr( c.textAttribute ) ) !== 'undefined' ) {
-					return $.trim( tmp );
+					return tmp.trim();
 				}
-				return $.trim( node.textContent || $node.text() );
+				return  node.textContent.trim() || $node.text().trim() ;
 			} else {
 				if ( typeof extract === 'function' ) {
-					return $.trim( extract( $node[ 0 ], c.table, cellIndex ) );
+					return  extract( $node[ 0 ], c.table, cellIndex ).trim() ;
 				} else if ( typeof ( tmp = ts.getColumnData( c.table, extract, cellIndex ) ) === 'function' ) {
-					return $.trim( tmp( $node[ 0 ], c.table, cellIndex ) );
+					return tmp( $node[ 0 ], c.table, cellIndex ).trim() ;
 				}
 			}
 			// fallback
-			return $.trim( $node[ 0 ].textContent || $node.text() );
+			return $node[ 0 ].textContent.trim() || $node.text().trim() ;
 		},
 
 		// centralized function to extract/parse cell contents
@@ -1026,7 +1027,7 @@
 				console[ console.table ? 'table' : 'log' ]( val );
 				if ( console.groupEnd ) { console.groupEnd(); }
 			}
-			if ( $.isFunction( callback ) ) {
+			if ( typeof callback === 'function'  ) {
 				callback( table );
 			}
 		},
@@ -1189,7 +1190,7 @@
 					tmp = $header.hasClass( ts.css.sortAsc ) ?
 						'sortAsc' :
 						$header.hasClass( ts.css.sortDesc ) ? 'sortDesc' : 'sortNone',
-					txt = $.trim( $header.text() ) + ': ' + ts.language[ tmp ];
+					txt = $header.text().trim()  + ': ' + ts.language[ tmp ];
 				if ( $header.hasClass( 'sorter-false' ) || nextSort === false ) {
 					txt += ts.language.sortDisabled;
 				} else {
@@ -1780,7 +1781,7 @@
 			if ( c.table.isUpdating ) {
 				c.$table.triggerHandler( 'updateComplete', c.table );
 			}
-			if ( $.isFunction( callback ) ) {
+			if ( typeof callback === 'function'  ) {
 				callback( c.table );
 			}
 		},
@@ -1830,7 +1831,7 @@
 			c.$table.triggerHandler( 'sortBeforeEnd', table );
 			c.$table.triggerHandler( 'sortEnd', table );
 			ts.applyWidget( table );
-			if ( $.isFunction( callback ) ) {
+			if ( typeof callback === 'function'  ) {
 				callback( table );
 			}
 		},
@@ -1845,7 +1846,7 @@
 			ts.setHeadersCss( c );
 			ts.multisort( c );
 			ts.appendCache( c );
-			if ( $.isFunction( callback ) ) {
+			if ( typeof callback === 'function' ) {
 				callback( c.table );
 			}
 		},
@@ -2267,7 +2268,7 @@
 			}
 			num = parseFloat( str );
 			// return the text instead of zero
-			return isNaN( num ) ? $.trim( str ) : num;
+			return isNaN( num ) ? str.trim()  : num;
 		},
 
 		isDigit : function( str ) {
@@ -2408,7 +2409,7 @@
 				// include sorter class name 'sorter-text', etc; now works with 'sorter-my-custom-parser'
 				val = cl4ss.match( new RegExp( '\\s' + key + '-([\\w-]+)' ) )[ 1 ] || '';
 			}
-			return $.trim( val );
+			return val.trim() ;
 		},
 
 		getColumnData : function( table, obj, indx, getCell, $headers ) {
@@ -2588,7 +2589,7 @@
 			}
 			// remove widget added rows, just in case
 			$h.find( 'tr' ).not( $r ).remove();
-			// disable tablesorter - not using .unbind( namespace ) because namespacing was
+			// disable tablesorter - not using .off( namespace ) because namespacing was
 			// added in jQuery v1.4.3 - see http://api.jquery.com/event.namespace/
 			events = 'sortReset update updateRows updateAll updateHeaders updateCell addRows updateComplete sorton ' +
 				'appendCache updateCache applyWidgetId applyWidgets refreshWidgets removeWidget destroy mouseup mouseleave ' +
@@ -2596,7 +2597,7 @@
 				.join( c.namespace + ' ' );
 			$t
 				.removeData( 'tablesorter' )
-				.unbind( events.replace( ts.regex.spaces, ' ' ) );
+				.off( events.replace( ts.regex.spaces, ' ' ) );
 			c.$headers
 				.add( $f )
 				.removeClass( [ ts.css.header, c.cssHeader, c.cssAsc, c.cssDesc, ts.css.sortAsc, ts.css.sortDesc, ts.css.sortNone ].join( ' ' ) )
@@ -2605,7 +2606,7 @@
 				.attr( 'aria-disabled', 'true' );
 			$r
 				.find( c.selectorSort )
-				.unbind( ( 'mousedown mouseup keypress '.split( ' ' ).join( c.namespace + ' ' ) ).replace( ts.regex.spaces, ' ' ) );
+				.off( ( 'mousedown mouseup keypress '.split( ' ' ).join( c.namespace + ' ' ) ).replace( ts.regex.spaces, ' ' ) );
 			ts.restoreHeaders( table );
 			$t.toggleClass( ts.css.table + ' ' + c.tableClass + ' tablesorter-' + c.theme, removeClasses === false );
 			$t.removeClass(c.namespace.slice(1));
@@ -2671,7 +2672,7 @@
 		format : function( str, table ) {
 			var c = table.config;
 			if ( str ) {
-				str = $.trim( c.ignoreCase ? str.toLocaleLowerCase() : str );
+				str = c.ignoreCase ? str.toLocaleLowerCase().trim() : str.trim() ;
 				str = c.sortLocaleCompare ? ts.replaceAccents( str ) : str;
 			}
 			return str;
@@ -2688,7 +2689,7 @@
 		format : function( str, table ) {
 			var num = ts.formatFloat( ( str || '' ).replace( ts.regex.nondigit, '' ), table );
 			return str && typeof num === 'number' ? num :
-				str ? $.trim( str && table.config.ignoreCase ? str.toLocaleLowerCase() : str ) : str;
+				str ? str && table.config.ignoreCase ? str.toLocaleLowerCase().trim() : str.trim()  : str;
 		},
 		type : 'numeric'
 	});
@@ -2705,7 +2706,7 @@
 		format : function( str, table ) {
 			var num = ts.formatFloat( ( str || '' ).replace( ts.regex.nondigit, '' ), table );
 			return str && typeof num === 'number' ? num :
-				str ? $.trim( str && table.config.ignoreCase ? str.toLocaleLowerCase() : str ) : str;
+				str ?  str && table.config.ignoreCase ? str.toLocaleLowerCase().trim() : str.trim()  : str;
 		},
 		type : 'numeric'
 	});
@@ -2720,7 +2721,7 @@
 			return ts.regex.urlProtocolTest.test( str );
 		},
 		format : function( str ) {
-			return str ? $.trim( str.replace( ts.regex.urlProtocolReplace, '' ) ) : str;
+			return str ?  str.replace( ts.regex.urlProtocolReplace, '' ).trim()  : str;
 		},
 		type : 'text'
 	});
@@ -2912,3 +2913,4 @@
 	});
 
 })( jQuery );
+return jQuery.tablesorter;}));

--- a/src/flask_debugtoolbar/static/js/toolbar.js
+++ b/src/flask_debugtoolbar/static/js/toolbar.js
@@ -1,5 +1,5 @@
 (function($) {
-  $.cookie = function(name, value, options) { if (typeof value != 'undefined') { options = options || {}; if (value === null) { value = ''; options.expires = -1; } var expires = ''; if (options.expires && (typeof options.expires == 'number' || options.expires.toUTCString)) { var date; if (typeof options.expires == 'number') { date = new Date(); date.setTime(date.getTime() + (options.expires * 24 * 60 * 60 * 1000)); } else { date = options.expires; } expires = '; expires=' + date.toUTCString(); } var path = options.path ? '; path=' + (options.path) : ''; var domain = options.domain ? '; domain=' + (options.domain) : ''; var secure = options.secure ? '; secure' : ''; document.cookie = [name, '=', encodeURIComponent(value), expires, path, domain, secure].join(''); } else { var cookieValue = null; if (document.cookie && document.cookie != '') { var cookies = document.cookie.split(';'); for (var i = 0; i < cookies.length; i++) { var cookie = $.trim(cookies[i]); if (cookie.substring(0, name.length + 1) == (name + '=')) { cookieValue = decodeURIComponent(cookie.substring(name.length + 1)); break; } } } return cookieValue; } };
+  $.cookie = function(name, value, options) { if (typeof value != 'undefined') { options = options || {}; if (value === null) { value = ''; options.expires = -1; } var expires = ''; if (options.expires && (typeof options.expires == 'number' || options.expires.toUTCString)) { var date; if (typeof options.expires == 'number') { date = new Date(); date.setTime(date.getTime() + (options.expires * 24 * 60 * 60 * 1000)); } else { date = options.expires; } expires = '; expires=' + date.toUTCString(); } var path = options.path ? '; path=' + (options.path) : ''; var domain = options.domain ? '; domain=' + (options.domain) : ''; var secure = options.secure ? '; secure' : ''; document.cookie = [name, '=', encodeURIComponent(value), expires, path, domain, secure].join(''); } else { var cookieValue = null; if (document.cookie && document.cookie != '') { var cookies = document.cookie.split(';'); for (var i = 0; i < cookies.length; i++) { var cookie = cookies[i].trim(); if (cookie.substring(0, name.length + 1) == (name + '=')) { cookieValue = decodeURIComponent(cookie.substring(name.length + 1)); break; } } } return cookieValue; } };
   $('head').append('<link rel="stylesheet" href="'+DEBUG_TOOLBAR_STATIC_PATH+'css/toolbar.css?'+ Math.random() +'" type="text/css" />');
   var COOKIE_NAME = 'fldt';
   var COOKIE_NAME_ACTIVE = COOKIE_NAME +'_active';
@@ -113,7 +113,7 @@
           });
           $(this).tablesorter({headers: headers});
         })
-        .bind('sortEnd', function() {
+        .on('sortEnd', function() {
           $(this).find('tbody tr').each(function(idx, elem) {
             var even = idx % 2 === 0;
             $(elem)
@@ -143,7 +143,7 @@
       $('#flDebugToolbar').hide('fast');
       $('#flDebugToolbarHandle').show();
       // Unbind keydown
-      $(document).unbind('keydown.flDebug');
+      $(document).off('keydown.flDebug');
       if (setCookie) {
         $.cookie(COOKIE_NAME, 'hide', {
           path: '/',


### PR DESCRIPTION
Bump tablesorter version to 2.3.0

Tablesorter only requires jquery 1.2.6+ which is long deprecated.
I've updated deprecated functions in Tablesorter and raised the required version to jQuery 3.5+

Updated deprecated jquery functions in toolbar.js as well. I'm sure there are more but I've cleaned up the obvious ones that seem to be throwing most console warnings.

https://github.com/pallets-eco/flask-debugtoolbar/issues/281
fixes #281 



