### PR TITLE
Fix class attribute dump_filename in ProfilerDebugPanel

### DIFF
--- a/src/flask_debugtoolbar/panels/profiler.py
+++ b/src/flask_debugtoolbar/panels/profiler.py
@@ -35,7 +35,7 @@ class ProfilerDebugPanel(DebugPanel):
         self, jinja_env: Environment, context: dict[str, t.Any] | None = None
     ) -> None:
         super().__init__(jinja_env, context=context)
-        
+
         self.dump_filename = None
 
         if current_app.config.get("DEBUG_TB_PROFILER_ENABLED"):


### PR DESCRIPTION
- Fixes #286
- We need `dump_filename` in `ProfilerDebugPanel` always initialised to avoid `AttributeError`

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in the contributing guide is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
