### PR TITLE
Security: Unsafe rendering of panel title/content allows XSS in custom or unsafe panels

### DIFF
--- a/src/flask_debugtoolbar/templates/base.html
+++ b/src/flask_debugtoolbar/templates/base.html
@@ -45,11 +45,11 @@
     <div id="{{ panel.dom_id() }}-content" class="flDebugPanelContentParent">
       <div class="flDebugPanelTitle">
         <a href="" class="flDebugClose">Close</a>
-        <h3>{{ panel.title()|safe }}</h3>
+        <h3>{{ panel.title() }}</h3>
       </div>
       <div class="flDebugPanelContent">
         <div class="flDebugScroll">
-          {{ panel.content()|safe }}
+          {{ panel.content() }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem

The base template renders `panel.title()` and `panel.content()` with `|safe`. If any panel (especially third-party/custom panels) returns unsanitized user-controlled data, this bypasses Jinja escaping and can lead to script injection in the debug toolbar UI.

**Severity**: `medium`
**File**: `src/flask_debugtoolbar/templates/base.html`

## Solution

Avoid blanket use of `|safe` for dynamic panel output. Prefer escaping by default and only mark trusted, sanitized HTML as safe (e.g., return `Markup` only from audited code paths). Document strict requirements for custom panel output sanitization.

## Changes

- `src/flask_debugtoolbar/templates/base.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
